### PR TITLE
fix(sui): generate builder functions for all entry functions regardless of visibility

### DIFF
--- a/packages/sui/src/codegen/codegen.ts
+++ b/packages/sui/src/codegen/codegen.ts
@@ -175,7 +175,7 @@ export class SuiCodegen extends AbstractCodegen<
   }
 
   protected generateBuilderForFunction(module: InternalMoveModule, func: InternalMoveFunction): string {
-    if (func.visibility !== InternalMoveFunctionVisibility.PUBLIC) {
+    if (func.visibility !== InternalMoveFunctionVisibility.PUBLIC && func.isEntry !== true) {
       return ''
     }
 


### PR DESCRIPTION
Fixes #75.

I'm not sure if this introduces an issue by allowing all entry functions to be in the builder namespace for codegen regardless of visibility though.