### PR TITLE
fix(sui): don't include txcontext arg in builder functions

### DIFF
--- a/packages/move/src/types.ts
+++ b/packages/move/src/types.ts
@@ -155,6 +155,11 @@ export class TypeDescriptor<T = any> {
     const parts = this.qname.split(SPLITTER)
     return parts[parts.length - 1]
   }
+
+  module(): string {
+    const parts = this.qname.split(SPLITTER)
+    return parts[parts.length - 2]
+  }
 }
 
 export function parseMoveType(type: string): TypeDescriptor {

--- a/packages/sui/src/codegen/codegen.ts
+++ b/packages/sui/src/codegen/codegen.ts
@@ -121,8 +121,11 @@ export class SuiCodegen extends AbstractCodegen<
 
   private generateArgs(module: InternalMoveModule, func: InternalMoveFunction) {
     const args = []
+    const argsLen = func.params.length
     for (const [idx, arg] of func.params.entries()) {
-      if (arg.reference) {
+      if (idx === argsLen - 1 && arg.name() == 'TxContext' && arg.module() == 'tx_context') {
+        continue
+      } else if (arg.reference) {
         args.push({
           paramType: `${this.ADDRESS_TYPE} | ObjectCallArg | TransactionArgument`,
           callValue: `_args.push(transactionArgumentOrObject(args[${idx}], tx))`
@@ -197,7 +200,7 @@ export class SuiCodegen extends AbstractCodegen<
     return `export function ${camel(normalizeToJSName(func.name))}${genericString}(tx: TransactionBlock, 
       args: [${args.map((a) => a.paramType).join(',')}],
       ${typeParamArg.length > 0 ? `typeArguments: [${typeParamArg}]` : ``} ):
-       TransactionArgument & [ ${'TransactionArgument,'.repeat(func.params.length)} ] {
+       TransactionArgument & [ ${'TransactionArgument,'.repeat(args.length)} ] {
       const _args: any[] = []
       ${args.map((a) => a.callValue).join('\n')}
       


### PR DESCRIPTION
TxContext args don't need to be passed to txb.moveCall() args, so this checks for TxContext being the last argument and don't include it in the codegen. It is still in the abi though. Again, I'm not sure if this breaks any tests so please check before merging :)