### PR TITLE
chore(claude): add project-level skills, hooks, and review subagents

### DIFF
--- a/.claude/agents/codegen-reviewer.md
+++ b/.claude/agents/codegen-reviewer.md
@@ -1,0 +1,68 @@
+---
+name: codegen-reviewer
+description: Review changes to typemove's code generation. The codegen is the core value of this library — it produces the committed builtin/0x*.ts files and downstream sentio-sdk Move processors depend on its output shape. Use whenever code under packages/move/src/codegen/, packages/aptos/src/codegen/, packages/sui/src/codegen/, packages/iota/src/codegen/, or any of the abstract coder files (abstract-move-coder.ts, internal-models.ts, ts-type.ts) is modified.
+tools: Read, Glob, Grep, Bash
+---
+
+You review changes to typemove's Move-to-TypeScript code generation. This is the codebase's core value: it produces the committed `packages/*/src/builtin/0x*.ts` files and is consumed by sentio-sdk's Move processors.
+
+## Areas of concern
+
+When reviewing a codegen change, evaluate these dimensions:
+
+1. **ABI → TS type mapping correctness**
+   - Move primitives map to the right TS type: `u8/u16/u32` → `number`, `u64/u128/u256` → `bigint`, `address` → string, `bool` → boolean, `vector<T>` → `T[]`
+   - `bigint` is preferred over `string` per the project's stated philosophy (CLAUDE.md "Use `bigint` instead of `string` for better type safety")
+   - Generics, phantom types, and type parameters are preserved
+
+2. **BigInt handling**
+   - Encoding/decoding round-trips correctly
+   - `0n` vs `null` semantics (see commit `7d98664f fix(view): encode 0n convert to null`)
+   - JSON serialization doesn't silently convert bigint to number
+
+3. **Module dependency resolution**
+   - Dependent modules are emitted in the right order
+   - Cross-package imports point at the right `@typemove/<chain>` path
+   - `index.ts` re-exports stay in sync with new/removed modules
+
+4. **Generated output stability**
+   - Diff `packages/*/src/builtin/0x*.ts` — output should change only where the codegen logic intends. Spurious whitespace/ordering churn is a regression.
+   - Run `pnpm --filter @typemove/<chain> gen` and check `git diff` is minimal and intentional.
+
+5. **Chain-specific quirks**
+   - Aptos: structs with `drop + store` abilities are treated as events (commit `54a015b0`).
+   - Aptos: `viewJson` option in constructor for view calls (commit `21dbcdd6`).
+   - Sui: enum type support (commit `2cb7d695`).
+   - Sui: precise type decoding (commit `375650c7`).
+   - Account type strings (`0x1` vs full address) — commit `349a7e38` standardized on `0x1`.
+
+6. **Downstream impact**
+   - sentio-sdk's Move processors import from `@typemove/aptos`, `@typemove/sui`, `@typemove/iota`. Breaking changes to the generated output's public shape are sentio-sdk breakage.
+   - If the change alters the shape of generated types, mention it explicitly so the user can coordinate the sentio-sdk side.
+
+## What to do
+
+1. Read the diff (use `git diff` if no specific files given).
+2. For each finding, give: file:line, what's wrong, why it matters, suggested fix.
+3. Run `pnpm --filter @typemove/<chain> gen` for each affected chain and inspect the resulting `git diff packages/<chain>/src/builtin/` — call out unexpected changes.
+4. Run `pnpm --filter @typemove/<chain> test` if behavior changes; report failures.
+
+## Output format
+
+```
+## Codegen review
+
+### Blocking
+- <file:line> — <issue> — <fix>
+
+### Concerns
+- <file:line> — <issue>
+
+### Generated output diff summary
+<one paragraph: was the diff minimal/intentional? any surprises?>
+
+### Downstream impact
+<one line: does sentio-sdk need a follow-up? yes/no + why>
+```
+
+Be terse. No findings is a valid result — say "looks clean" and stop.

--- a/.claude/agents/multi-chain-consistency-reviewer.md
+++ b/.claude/agents/multi-chain-consistency-reviewer.md
@@ -1,0 +1,50 @@
+---
+name: multi-chain-consistency-reviewer
+description: Use after editing files inside packages/aptos/, packages/sui/, or packages/iota/ to check whether a parallel file in the sibling chain packages should receive the same change. The three chain packages intentionally mirror each other, and forgetting to update siblings is a common drift source. Pass the list of files you touched and the chain you focused on.
+tools: Read, Glob, Grep, Bash
+---
+
+You are a reviewer for the typemove monorepo, which contains three chain packages that intentionally mirror each other:
+
+- `packages/aptos/` — Aptos bindings
+- `packages/sui/` — Sui bindings
+- `packages/iota/` — Iota bindings (derived from Sui; has a `sync-from-sui.ts` script)
+
+Many files exist in parallel across these packages with similar shapes:
+- `move-coder.ts`
+- `chain-adapter.ts` (Aptos/Sui) / equivalents in Iota
+- `to-internal.ts`
+- `coder-helpers.ts`
+- `codegen/run.ts`, `codegen/codegen.ts`
+- `tests/move-call.test.ts`, `tests/move-coder.test.ts`
+
+Iota is especially likely to need parallel updates because it was forked from Sui — see commit `340c5ea3 feat(iota): upgrade to new sdk` for the canonical pattern.
+
+## Your job
+
+Given a list of changed files in one chain package, decide whether sibling chain packages need the same change.
+
+1. For each changed file, locate parallel files in the other chain packages (use `Glob` and `Read`).
+2. Diff the relevant section conceptually — does the change apply to the sibling? Reasons it might NOT:
+   - The change addresses a chain-specific quirk (e.g. Aptos `event` ability detection, Sui `enum` types, Iota SDK API specifics).
+   - The sibling already has equivalent logic written differently.
+   - The change is in a chain-specific module (e.g. `account-resource-client.ts` only exists in Aptos).
+3. For each sibling where the change *should* propagate, report the specific file and what to update.
+
+## Output format
+
+A short report:
+
+```
+## Multi-chain consistency check
+
+Changed in <chain>: <count> files
+
+### Propagate to <sibling-chain>
+- packages/<sibling>/src/<file> — <one-line reason and what to change>
+
+### Skip <sibling-chain>
+- Reason: <chain-specific quirk or already equivalent>
+```
+
+Keep it tight. Don't speculate — only flag concrete parallels you verified by reading both files. If everything checks out, say so in one line.

--- a/.claude/hooks/block-builtin-edits.sh
+++ b/.claude/hooks/block-builtin-edits.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# PreToolUse hook: refuse edits to packages/<chain>/src/builtin/0x*.ts
+# These files are codegen outputs. Hand-edits get wiped on the next `pnpm gen`.
+# Fix the codegen source or ABIs instead, then re-run codegen via the regen-builtins skill.
+
+set -euo pipefail
+
+input="$(cat)"
+file_path="$(printf '%s' "$input" | /usr/bin/env jq -r '.tool_input.file_path // empty')"
+
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+case "$file_path" in
+  */packages/aptos/src/builtin/0x*.ts \
+  | */packages/sui/src/builtin/0x*.ts \
+  | */packages/iota/src/builtin/0x*.ts)
+    cat >&2 <<EOF
+Refusing to edit $file_path: this is a codegen output.
+
+Hand-edits will be overwritten the next time \`pnpm gen\` runs in the chain package.
+Fix the codegen logic (packages/<chain>/src/codegen/) or the ABI (packages/<chain>/src/abis/),
+then regenerate via the \`regen-builtins\` skill or \`cd packages/<chain> && pnpm gen\`.
+EOF
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-builtin-edits.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | xargs -I {} sh -c 'case \"{}\" in *.ts|*.tsx|*.js|*.mjs|*.cjs|*.json|*.yml|*.yaml|*.md) cd \"$CLAUDE_PROJECT_DIR\" && pnpm exec prettier --write --log-level warn \"{}\" 2>/dev/null || true ;; esac'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/bump-chain-sdk/SKILL.md
+++ b/.claude/skills/bump-chain-sdk/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: bump-chain-sdk
+description: Bump an Aptos/Sui/Iota SDK version in this monorepo, regenerate builtin and test types, run tests, and prepare a conventional commit. Use when the user asks to upgrade @aptos-labs/ts-sdk, @mysten/sui, @iota/iota-sdk, or any chain SDK version.
+disable-model-invocation: true
+---
+
+# Bump Chain SDK
+
+Upgrade an Aptos / Sui / Iota SDK version inside this typemove monorepo and propagate the changes through codegen + tests + commit.
+
+## When to use
+
+User says something like:
+- "Bump Iota SDK to 1.10.0"
+- "Upgrade Sui SDK to the latest"
+- "Update @aptos-labs/ts-sdk to 6.1.0"
+
+## Inputs to confirm
+
+Before doing anything, confirm with the user:
+- **Chain**: `aptos`, `sui`, or `iota`
+- **Target version**: e.g. `1.10.0`, or `latest` if they want you to pick
+
+## Steps
+
+1. **Locate the target package.json**
+   - `packages/aptos/package.json` → `@aptos-labs/ts-sdk`
+   - `packages/sui/package.json` → `@mysten/sui`
+   - `packages/iota/package.json` → `@iota/iota-sdk`
+   - Some upgrades also touch the root `package.json` (see commit `472da443` for the Iota 1.10.0 precedent — root `package.json` and `pnpm-lock.yaml` were updated alongside the chain package).
+
+2. **Update the version** in package.json and run `pnpm install` from the repo root to refresh `pnpm-lock.yaml`.
+
+3. **Regenerate builtin types** for the affected chain. Run from the chain package directory:
+   ```bash
+   cd packages/<chain> && pnpm gen
+   ```
+   This regenerates `src/builtin/0x1.ts`, `0x2.ts`, `0x3.ts` (Sui/Iota) or `0x1.ts`, `0x3.ts`, `0x4.ts` (Aptos).
+
+4. **Regenerate test types**:
+   ```bash
+   cd packages/<chain> && pnpm gen:test
+   ```
+
+5. **Build the package** to surface any breakage from SDK API changes:
+   ```bash
+   pnpm --filter @typemove/<chain> build
+   ```
+   If TypeScript errors appear, they are almost always SDK breaking changes — fix them in `move-coder.ts`, `to-internal.ts`, `chain-adapter.ts`, or the codegen output. Don't hand-edit `src/builtin/` files — fix the codegen source instead.
+
+6. **Run tests for the chain**:
+   ```bash
+   pnpm --filter @typemove/<chain> test
+   ```
+
+7. **Check sibling chains for shared breakage**. SDK upgrades sometimes change shared @typemove/move interfaces. If you touched anything outside `packages/<chain>/`, run `pnpm test:all` and `pnpm build:all`.
+
+8. **Stage and commit** using the canonical message format from history:
+   ```
+   chore: upgrade <Chain> SDK to <version>
+   ```
+   Examples from `git log`: `chore: upgrade Iota SDK to 1.10.0`, `chore: upgrade Sui SDK to 2.4.0`.
+   Note: these specific upgrade commits use a bare `chore:` prefix without a scope, even though `CLAUDE.md` recommends `chore(deps):` generally. Follow the existing pattern for chain-SDK bumps.
+
+9. **Create the PR** per CLAUDE.md: this repo is PR-only, never push to main. Use `git dev <name>/bump-<chain>-<version>` (custom shortcut from `.github/.gitconfig`) or `git checkout -b dev/<name>/bump-<chain>-<version>`, then `gh pr create`.
+
+## Things to watch for
+
+- **GitHub Actions workflows** sometimes need a matching version bump (e.g. `472da443` touched all four `.github/workflows/*.yaml` files). Grep `.github/workflows/` for the old version string before committing.
+- **iota `sync-from-sui` script**: Iota's codegen historically mirrors Sui's. If you bump Sui you may also want to run `pnpm --filter @typemove/iota sync-from-sui` and re-test Iota.
+- **Don't manually edit `packages/*/src/builtin/0x*.ts`** — they are codegen outputs and a PreToolUse hook will block edits.

--- a/.claude/skills/regen-builtins/SKILL.md
+++ b/.claude/skills/regen-builtins/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: regen-builtins
+description: Regenerate the committed builtin/0x* TypeScript bindings for a chain package (aptos, sui, or iota) by running its codegen. Use when ABIs change, after upgrading an SDK, or whenever the builtin/ output is stale relative to src/abis/.
+---
+
+# Regenerate Builtins
+
+Run a chain package's codegen to refresh `packages/<chain>/src/builtin/0x*.ts`.
+
+## When to use
+
+- ABIs under `packages/<chain>/src/abis/` changed
+- Codegen logic under `packages/<chain>/src/codegen/` or `packages/move/src/codegen/` changed
+- After bumping a chain SDK (see also: `bump-chain-sdk` skill)
+- The committed `builtin/` files look stale or someone hand-edited them by mistake
+
+## How to run
+
+Each chain package has its own `gen` script that targets the right addresses. Run it from the package directory:
+
+| Chain | Command | Addresses generated |
+|-------|---------|--------------------|
+| Aptos | `cd packages/aptos && pnpm gen` | `0x1`, `0x3`, `0x4` |
+| Sui   | `cd packages/sui && pnpm gen`   | `0x1`, `0x2`, `0x3` |
+| Iota  | `cd packages/iota && pnpm gen`  | `0x1`, `0x2`, `0x3` |
+
+Test types live elsewhere and have a separate script:
+
+| Chain | Command | Output |
+|-------|---------|--------|
+| Aptos | `cd packages/aptos && pnpm gen:test` | `src/tests/types/` |
+| Sui   | `cd packages/sui && pnpm gen:test`   | `src/tests/types/testnet/` |
+| Iota  | `cd packages/iota && pnpm gen:test`  | `src/tests/types/testnet/` |
+
+## After regenerating
+
+- Run `pnpm --filter @typemove/<chain> build` to confirm the new output compiles.
+- Run `pnpm --filter @typemove/<chain> test` to make sure tests still pass against the new types.
+- The output is committed — diff it (`git diff packages/<chain>/src/builtin/`) and include it in the same PR as whatever triggered the regeneration.
+
+## Notes
+
+- Do not hand-edit `packages/*/src/builtin/0x*.ts`. They are deterministic codegen outputs and a PreToolUse hook blocks direct edits. Fix the source (ABIs, codegen) and re-run this skill.
+- The codegen entrypoint is `tsx src/codegen/run.ts` in each chain package; `pnpm gen` is just the canonical invocation. Refer to the package's `package.json` `scripts._gen` for the exact flags.


### PR DESCRIPTION
## Summary

Adds typemove-specific Claude Code configuration under `.claude/` so anyone using Claude Code on this repo gets the same skills, review subagents, and edit guards. No runtime code changes.

## What's included

**Skills** (`.claude/skills/`)
- `bump-chain-sdk` — user-only (`disable-model-invocation: true`). Codifies the recurring Aptos/Sui/Iota SDK upgrade workflow: bump the right `package.json`, run `pnpm gen` + `pnpm gen:test`, fix breakage, run tests, commit with the canonical `chore: upgrade <Chain> SDK to <version>` message used in `472da443` / `601924cf`.
- `regen-builtins` — both-invocable. Runs the right `pnpm gen` / `pnpm gen:test` for the chain you point it at and reminds you to diff `packages/<chain>/src/builtin/`.

**Subagents** (`.claude/agents/`)
- `multi-chain-consistency-reviewer` — given files changed in one chain, identifies parallel files in the sibling chain packages that may need the same change. The three chain packages intentionally mirror each other (Iota was forked from Sui) and drift is a known footgun.
- `codegen-reviewer` — reviews changes to `packages/*/src/codegen/` and the abstract coder files against ABI→TS mapping correctness, BigInt handling (incl. `0n` ↔ `null` from `7d98664f`), module dependency resolution, and downstream sentio-sdk impact.

**Hooks** (`.claude/settings.json` + `.claude/hooks/`)
- **PreToolUse `Edit|Write|MultiEdit`** → `block-builtin-edits.sh` refuses direct edits to `packages/{aptos,sui,iota}/src/builtin/0x*.ts`. Those files are codegen outputs and hand-edits get wiped by the next `pnpm gen`. The error message points the user back to the codegen source / the `regen-builtins` skill.
- **PostToolUse `Edit|Write|MultiEdit`** → `pnpm exec prettier --write` on edited TS/JSON/YAML/MD files, matching what `.lintstagedrc` already enforces at commit time. Keeps Claude's output from generating format-only diffs at commit.

## Why now

Recent history shows SDK upgrades (`chore: upgrade Iota SDK to 1.10.0`, `chore: upgrade Sui SDK to 2.4.0`) and codegen-adjacent changes are recurring, multi-step, and easy to do inconsistently. Putting the workflow in a skill makes it one invocation; putting the guards in hooks makes it impossible to skip.

## Test plan

- [x] Pre-commit hook (lint-staged + ls-lint) passes — verified during commit.
- [x] Pre-push hook (eslint) passes — verified during push (warnings are pre-existing in `account-resource-client.test.ts`, unrelated to this change).
- [x] `block-builtin-edits.sh` returns exit 2 when given `packages/aptos/src/builtin/0x1.ts`, exit 0 for `packages/aptos/src/move-coder.ts`.
- [ ] Reviewer: open Claude Code at the repo root and confirm the skills/agents show up in the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)