### PR TITLE
refactor(aptos): strip bytecode at fetch time, drop persist hook

### DIFF
--- a/packages/aptos/src/aptos-chain-adapter.ts
+++ b/packages/aptos/src/aptos-chain-adapter.ts
@@ -10,6 +10,13 @@ import {
 import { Aptos, Event, MoveModuleBytecode, MoveResource } from '@aptos-labs/ts-sdk'
 import { toInternalModule } from './to-internal.js'
 
+// Drop bytecode — typemove's codegen only reads `m.abi`, and bytecode is
+// ~50% of each Aptos module entry's bytes. Cast is needed because
+// MoveModuleBytecode declares `bytecode: string` as required.
+function stripBytecode({ abi }: MoveModuleBytecode): MoveModuleBytecode {
+  return { abi } as MoveModuleBytecode
+}
+
 export class AptosChainAdapter extends ChainAdapter<MoveModuleBytecode, Event | MoveResource> {
   // static INSTANCE = new AptosChainAdapter()
   client: Aptos
@@ -22,26 +29,22 @@ export class AptosChainAdapter extends ChainAdapter<MoveModuleBytecode, Event | 
   }
 
   async fetchModules(account: string): Promise<MoveModuleBytecode[]> {
-    return await this.client.getAccountModules({
+    const modules = await this.client.getAccountModules({
       accountAddress: account
     })
+    return modules.map(stripBytecode)
   }
 
   async fetchModule(account: string, module: string): Promise<MoveModuleBytecode> {
-    return await this.client.getAccountModule({
+    const m = await this.client.getAccountModule({
       accountAddress: account,
       moduleName: module
     })
+    return stripBytecode(m)
   }
 
   toInternalModules(modules: MoveModuleBytecode[]): InternalMoveModule[] {
     return modules.flatMap((m) => (m.abi ? [toInternalModule(m)] : []))
-  }
-
-  // Drop bytecode from cached ABI files — only `abi` is consumed by codegen,
-  // and bytecode is ~50% of each Aptos ABI JSON's bytes.
-  override toPersistableModules(modules: MoveModuleBytecode[]) {
-    return modules.map(({ abi }) => ({ abi }))
   }
 
   getMeaningfulFunctionParams(params: TypeDescriptor[]): TypeDescriptor[] {

--- a/packages/aptos/src/codegen/run.ts
+++ b/packages/aptos/src/codegen/run.ts
@@ -52,15 +52,12 @@ program
     let abisDir = location
     if (location.startsWith('0x')) {
       const abiAddress = abisDir
-      const abi = await aptosClient.getAccountModules({ accountAddress: abiAddress })
+      const abi = await new AptosChainAdapter(aptosClient).fetchModules(abiAddress)
       abisDir = options.abiDir
       if (!fs.existsSync(abisDir)) {
         fs.mkdirSync(abisDir, { recursive: true })
       }
-      fs.writeFileSync(
-        path.join(abisDir, abiAddress + '.json'),
-        JSON.stringify(new AptosChainAdapter(aptosClient).toPersistableModules(abi), null, 2)
-      )
+      fs.writeFileSync(path.join(abisDir, abiAddress + '.json'), JSON.stringify(abi, null, 2))
     }
 
     const num = await codegen(abisDir, options.targetDir, config, true)

--- a/packages/move/src/chain-adapter.ts
+++ b/packages/move/src/chain-adapter.ts
@@ -14,14 +14,6 @@ export abstract class ChainAdapter<ModuleType, StructType> {
   abstract fetchModules(account: string): Promise<ModuleType[]>
   abstract toInternalModules(modules: ModuleType[]): InternalMoveModule[]
 
-  // Hook called before fetched modules are written to the ABI cache on disk
-  // (src/abis/<account>.json). Chains can strip fields that are not needed for
-  // codegen — e.g. Aptos drops `bytecode` since only `abi` is consumed,
-  // roughly halving the committed + published ABI file size.
-  toPersistableModules(modules: ModuleType[]): unknown {
-    return modules
-  }
-
   // Get all structs that represent Events
   abstract getAllEventStructs(module: InternalMoveModule[]): Map<string, InternalMoveStruct>
 

--- a/packages/move/src/codegen/abstract-codegen.ts
+++ b/packages/move/src/codegen/abstract-codegen.ts
@@ -118,10 +118,7 @@ export abstract class AbstractCodegen<ModuleTypes, StructType> {
           )
           const modules = this.chainAdapter.toInternalModules(rawModules)
 
-          fs.writeFileSync(
-            path.resolve(srcDir, account + '.json'),
-            JSON.stringify(this.chainAdapter.toPersistableModules(rawModules), null, '\t')
-          )
+          fs.writeFileSync(path.resolve(srcDir, account + '.json'), JSON.stringify(rawModules, null, '\t'))
           for (const module of modules) {
             loader.register(module, account)
           }


### PR DESCRIPTION
## Summary

Follow-up to [#165](https://github.com/sentioxyz/typemove/pull/165). Stripping bytecode at the *cache-write* boundary was unnecessary indirection — typemove never reads `bytecode` in the first place, so there's no reason to carry it past the SDK call.

Moves the strip into `AptosChainAdapter.fetchModules` / `fetchModule` so bytecode never enters memory beyond the SDK response. This lets us:

- Delete `ChainAdapter.toPersistableModules` entirely.
- Revert the unrelated change in `packages/move/src/codegen/abstract-codegen.ts` (the cross-account dep loop now just writes `rawModules` directly).
- Switch `packages/aptos/src/codegen/run.ts` to go through `adapter.fetchModules()` instead of calling the SDK directly, so the top-level download gets bytecode-free data the same way as the dep loop.

## Net diff

```
 packages/aptos/src/aptos-chain-adapter.ts     | 19 +++++++++++--------
 packages/aptos/src/codegen/run.ts             |  7 ++-----
 packages/move/src/chain-adapter.ts            |  8 --------
 packages/move/src/codegen/abstract-codegen.ts |  5 +----
 4 files changed, 14 insertions(+), 25 deletions(-)
```

All Aptos-specific logic now lives in `aptos-chain-adapter.ts`; the shared `@typemove/move` package is back to its pre-#165 state.

## Test plan

- [x] `pnpm --filter @typemove/move build` clean
- [x] `pnpm --filter @typemove/{aptos,sui,iota} exec tsc` clean
- [x] `pnpm --filter @typemove/aptos test` — 20/20 pass, 1 skip
- [x] Re-ran `pnpm gen` for aptos; regenerated ABIs identical to those landed in #165 (still bytecode-free, same sizes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)