### PR TITLE
chore: upgrade Sui SDK to 2.17.0

### DIFF
--- a/packages/sui/package.json
+++ b/packages/sui/package.json
@@ -30,7 +30,7 @@
   },
   "types": "./dist/esm/index.d.ts",
   "dependencies": {
-    "@mysten/sui": "~2.4.0",
+    "@mysten/sui": "~2.17.0",
     "@typemove/move": "workspace:*",
     "chalk": "^5.3.0",
     "commander": "^14.0.0",

--- a/packages/sui/src/abis/0x1.json
+++ b/packages/sui/src/abis/0x1.json
@@ -1,6 +1,6 @@
 {
   "address": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "address",
     "friends": [],
@@ -18,7 +18,7 @@
     }
   },
   "ascii": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "ascii",
     "friends": [],
@@ -492,7 +492,7 @@
     }
   },
   "bcs": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "bcs",
     "friends": [],
@@ -522,7 +522,7 @@
     }
   },
   "bit_vector": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "bit_vector",
     "friends": [],
@@ -691,7 +691,7 @@
     }
   },
   "bool": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "bool",
     "friends": [],
@@ -699,7 +699,7 @@
     "exposedFunctions": {}
   },
   "debug": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "debug",
     "friends": [],
@@ -732,7 +732,7 @@
     }
   },
   "fixed_point32": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "fixed_point32",
     "friends": [],
@@ -869,7 +869,7 @@
     }
   },
   "hash": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "hash",
     "friends": [],
@@ -908,7 +908,7 @@
     }
   },
   "internal": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "internal",
     "friends": [],
@@ -963,7 +963,7 @@
     }
   },
   "macros": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "macros",
     "friends": [
@@ -1004,7 +1004,7 @@
     "exposedFunctions": {}
   },
   "option": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "option",
     "friends": [],
@@ -1568,7 +1568,7 @@
     }
   },
   "string": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "string",
     "friends": [],
@@ -1965,7 +1965,7 @@
     }
   },
   "type_name": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "type_name",
     "friends": [],
@@ -2342,7 +2342,7 @@
     }
   },
   "u128": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "u128",
     "friends": [],
@@ -2497,6 +2497,18 @@
           "U128"
         ]
       },
+      "div_ceil": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          "U128",
+          "U128"
+        ],
+        "return": [
+          "U128"
+        ]
+      },
       "divide_and_round_up": {
         "visibility": "Public",
         "isEntry": false,
@@ -2589,6 +2601,32 @@
         "isEntry": false,
         "typeParameters": [],
         "parameters": [
+          "U128",
+          "U128"
+        ],
+        "return": [
+          "U128"
+        ]
+      },
+      "mul_div": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          "U128",
+          "U128",
+          "U128"
+        ],
+        "return": [
+          "U128"
+        ]
+      },
+      "mul_div_ceil": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          "U128",
           "U128",
           "U128"
         ],
@@ -2756,7 +2794,7 @@
     }
   },
   "u16": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "u16",
     "friends": [],
@@ -2911,6 +2949,18 @@
           "U16"
         ]
       },
+      "div_ceil": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          "U16",
+          "U16"
+        ],
+        "return": [
+          "U16"
+        ]
+      },
       "divide_and_round_up": {
         "visibility": "Public",
         "isEntry": false,
@@ -3003,6 +3053,32 @@
         "isEntry": false,
         "typeParameters": [],
         "parameters": [
+          "U16",
+          "U16"
+        ],
+        "return": [
+          "U16"
+        ]
+      },
+      "mul_div": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          "U16",
+          "U16",
+          "U16"
+        ],
+        "return": [
+          "U16"
+        ]
+      },
+      "mul_div_ceil": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          "U16",
           "U16",
           "U16"
         ],
@@ -3110,7 +3186,7 @@
     }
   },
   "u256": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "u256",
     "friends": [],
@@ -3212,6 +3288,18 @@
         ]
       },
       "diff": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          "U256",
+          "U256"
+        ],
+        "return": [
+          "U256"
+        ]
+      },
+      "div_ceil": {
         "visibility": "Public",
         "isEntry": false,
         "typeParameters": [],
@@ -3491,7 +3579,7 @@
     }
   },
   "u32": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "u32",
     "friends": [],
@@ -3646,6 +3734,18 @@
           "U32"
         ]
       },
+      "div_ceil": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          "U32",
+          "U32"
+        ],
+        "return": [
+          "U32"
+        ]
+      },
       "divide_and_round_up": {
         "visibility": "Public",
         "isEntry": false,
@@ -3738,6 +3838,32 @@
         "isEntry": false,
         "typeParameters": [],
         "parameters": [
+          "U32",
+          "U32"
+        ],
+        "return": [
+          "U32"
+        ]
+      },
+      "mul_div": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          "U32",
+          "U32",
+          "U32"
+        ],
+        "return": [
+          "U32"
+        ]
+      },
+      "mul_div_ceil": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          "U32",
           "U32",
           "U32"
         ],
@@ -3865,7 +3991,7 @@
     }
   },
   "u64": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "u64",
     "friends": [],
@@ -4020,6 +4146,18 @@
           "U64"
         ]
       },
+      "div_ceil": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          "U64",
+          "U64"
+        ],
+        "return": [
+          "U64"
+        ]
+      },
       "divide_and_round_up": {
         "visibility": "Public",
         "isEntry": false,
@@ -4112,6 +4250,32 @@
         "isEntry": false,
         "typeParameters": [],
         "parameters": [
+          "U64",
+          "U64"
+        ],
+        "return": [
+          "U64"
+        ]
+      },
+      "mul_div": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          "U64",
+          "U64",
+          "U64"
+        ],
+        "return": [
+          "U64"
+        ]
+      },
+      "mul_div_ceil": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          "U64",
           "U64",
           "U64"
         ],
@@ -4259,7 +4423,7 @@
     }
   },
   "u8": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "u8",
     "friends": [],
@@ -4414,6 +4578,18 @@
           "U8"
         ]
       },
+      "div_ceil": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          "U8",
+          "U8"
+        ],
+        "return": [
+          "U8"
+        ]
+      },
       "divide_and_round_up": {
         "visibility": "Public",
         "isEntry": false,
@@ -4513,6 +4689,32 @@
           "U8"
         ]
       },
+      "mul_div": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          "U8",
+          "U8",
+          "U8"
+        ],
+        "return": [
+          "U8"
+        ]
+      },
+      "mul_div_ceil": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          "U8",
+          "U8",
+          "U8"
+        ],
+        "return": [
+          "U8"
+        ]
+      },
       "pow": {
         "visibility": "Public",
         "isEntry": false,
@@ -4593,7 +4795,7 @@
     }
   },
   "uq32_32": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "uq32_32",
     "friends": [],
@@ -4984,7 +5186,7 @@
     }
   },
   "uq64_64": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "uq64_64",
     "friends": [],
@@ -5375,7 +5577,7 @@
     }
   },
   "vector": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x1",
     "name": "vector",
     "friends": [],

--- a/packages/sui/src/abis/0x2.json
+++ b/packages/sui/src/abis/0x2.json
@@ -1,6 +1,6 @@
 {
   "accumulator": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "accumulator",
     "friends": [
@@ -558,7 +558,7 @@
     }
   },
   "accumulator_metadata": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "accumulator_metadata",
     "friends": [],
@@ -675,7 +675,7 @@
     "exposedFunctions": {}
   },
   "accumulator_settlement": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "accumulator_settlement",
     "friends": [],
@@ -708,7 +708,7 @@
     "exposedFunctions": {}
   },
   "address": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "address",
     "friends": [],
@@ -834,7 +834,7 @@
     }
   },
   "address_alias": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "address_alias",
     "friends": [],
@@ -1006,7 +1006,7 @@
     }
   },
   "authenticator_state": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "authenticator_state",
     "friends": [],
@@ -1195,7 +1195,7 @@
     "exposedFunctions": {}
   },
   "bag": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "bag",
     "friends": [],
@@ -1536,7 +1536,7 @@
     }
   },
   "balance": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "balance",
     "friends": [
@@ -2121,7 +2121,7 @@
     }
   },
   "bcs": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "bcs",
     "friends": [],
@@ -2842,7 +2842,7 @@
     }
   },
   "bls12381": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "bls12381",
     "friends": [],
@@ -4930,7 +4930,7 @@
     }
   },
   "borrow": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "borrow",
     "friends": [],
@@ -5155,7 +5155,7 @@
     }
   },
   "clock": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "clock",
     "friends": [],
@@ -5210,7 +5210,7 @@
     }
   },
   "coin": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "coin",
     "friends": [
@@ -10047,7 +10047,7 @@
     }
   },
   "config": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "config",
     "friends": [
@@ -10703,7 +10703,7 @@
     }
   },
   "deny_list": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "deny_list",
     "friends": [
@@ -11440,10 +11440,15 @@
     }
   },
   "display": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "display",
-    "friends": [],
+    "friends": [
+      {
+        "address": "0x2",
+        "name": "display_registry"
+      }
+    ],
     "structs": {
       "Display": {
         "abilities": {
@@ -11725,6 +11730,32 @@
                 "name": "TxContext",
                 "typeArguments": []
               }
+            }
+          }
+        ],
+        "return": []
+      },
+      "destroy": {
+        "visibility": "Friend",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": [
+              "Key"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "display",
+              "name": "Display",
+              "typeArguments": [
+                {
+                  "TypeParameter": 0
+                }
+              ]
             }
           }
         ],
@@ -12066,8 +12097,931 @@
       }
     }
   },
+  "display_registry": {
+    "fileFormatVersion": 7,
+    "address": "0x2",
+    "name": "display_registry",
+    "friends": [],
+    "structs": {
+      "Display": {
+        "abilities": {
+          "abilities": [
+            "Key"
+          ]
+        },
+        "typeParameters": [
+          {
+            "constraints": {
+              "abilities": []
+            },
+            "isPhantom": true
+          }
+        ],
+        "fields": [
+          {
+            "name": "id",
+            "type": {
+              "Struct": {
+                "address": "0x2",
+                "module": "object",
+                "name": "UID",
+                "typeArguments": []
+              }
+            }
+          },
+          {
+            "name": "fields",
+            "type": {
+              "Struct": {
+                "address": "0x2",
+                "module": "vec_map",
+                "name": "VecMap",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x1",
+                      "module": "string",
+                      "name": "String",
+                      "typeArguments": []
+                    }
+                  },
+                  {
+                    "Struct": {
+                      "address": "0x1",
+                      "module": "string",
+                      "name": "String",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "cap_id",
+            "type": {
+              "Struct": {
+                "address": "0x1",
+                "module": "option",
+                "name": "Option",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "object",
+                      "name": "ID",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "DisplayCap": {
+        "abilities": {
+          "abilities": [
+            "Store",
+            "Key"
+          ]
+        },
+        "typeParameters": [
+          {
+            "constraints": {
+              "abilities": []
+            },
+            "isPhantom": true
+          }
+        ],
+        "fields": [
+          {
+            "name": "id",
+            "type": {
+              "Struct": {
+                "address": "0x2",
+                "module": "object",
+                "name": "UID",
+                "typeArguments": []
+              }
+            }
+          }
+        ]
+      },
+      "DisplayKey": {
+        "abilities": {
+          "abilities": [
+            "Copy",
+            "Drop",
+            "Store"
+          ]
+        },
+        "typeParameters": [
+          {
+            "constraints": {
+              "abilities": []
+            },
+            "isPhantom": true
+          }
+        ],
+        "fields": [
+          {
+            "name": "dummy_field",
+            "type": "Bool"
+          }
+        ]
+      },
+      "DisplayRegistry": {
+        "abilities": {
+          "abilities": [
+            "Key"
+          ]
+        },
+        "typeParameters": [],
+        "fields": [
+          {
+            "name": "id",
+            "type": {
+              "Struct": {
+                "address": "0x2",
+                "module": "object",
+                "name": "UID",
+                "typeArguments": []
+              }
+            }
+          }
+        ]
+      },
+      "SystemMigrationCap": {
+        "abilities": {
+          "abilities": [
+            "Key"
+          ]
+        },
+        "typeParameters": [],
+        "fields": [
+          {
+            "name": "id",
+            "type": {
+              "Struct": {
+                "address": "0x2",
+                "module": "object",
+                "name": "UID",
+                "typeArguments": []
+              }
+            }
+          }
+        ]
+      }
+    },
+    "exposedFunctions": {
+      "cap_id": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": []
+          }
+        ],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "display_registry",
+                "name": "Display",
+                "typeArguments": [
+                  {
+                    "TypeParameter": 0
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x1",
+              "module": "option",
+              "name": "Option",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "object",
+                    "name": "ID",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "claim": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": [
+              "Key"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "display_registry",
+                "name": "Display",
+                "typeArguments": [
+                  {
+                    "TypeParameter": 0
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "display",
+              "name": "Display",
+              "typeArguments": [
+                {
+                  "TypeParameter": 0
+                }
+              ]
+            }
+          },
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "tx_context",
+                "name": "TxContext",
+                "typeArguments": []
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "display_registry",
+              "name": "DisplayCap",
+              "typeArguments": [
+                {
+                  "TypeParameter": 0
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "claim_with_publisher": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": [
+              "Key"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "display_registry",
+                "name": "Display",
+                "typeArguments": [
+                  {
+                    "TypeParameter": 0
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "package",
+                "name": "Publisher",
+                "typeArguments": []
+              }
+            }
+          },
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "tx_context",
+                "name": "TxContext",
+                "typeArguments": []
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "display_registry",
+              "name": "DisplayCap",
+              "typeArguments": [
+                {
+                  "TypeParameter": 0
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "clear": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": []
+          }
+        ],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "display_registry",
+                "name": "Display",
+                "typeArguments": [
+                  {
+                    "TypeParameter": 0
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "display_registry",
+                "name": "DisplayCap",
+                "typeArguments": [
+                  {
+                    "TypeParameter": 0
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return": []
+      },
+      "delete_legacy": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": [
+              "Key"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "display_registry",
+                "name": "Display",
+                "typeArguments": [
+                  {
+                    "TypeParameter": 0
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "display",
+              "name": "Display",
+              "typeArguments": [
+                {
+                  "TypeParameter": 0
+                }
+              ]
+            }
+          }
+        ],
+        "return": []
+      },
+      "destroy_system_migration_cap": {
+        "visibility": "Private",
+        "isEntry": true,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "display_registry",
+              "name": "SystemMigrationCap",
+              "typeArguments": []
+            }
+          }
+        ],
+        "return": []
+      },
+      "fields": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": []
+          }
+        ],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "display_registry",
+                "name": "Display",
+                "typeArguments": [
+                  {
+                    "TypeParameter": 0
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "vec_map",
+                "name": "VecMap",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x1",
+                      "module": "string",
+                      "name": "String",
+                      "typeArguments": []
+                    }
+                  },
+                  {
+                    "Struct": {
+                      "address": "0x1",
+                      "module": "string",
+                      "name": "String",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "migrate_v1_to_v2": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": [
+              "Key"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "display_registry",
+                "name": "DisplayRegistry",
+                "typeArguments": []
+              }
+            }
+          },
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "display",
+              "name": "Display",
+              "typeArguments": [
+                {
+                  "TypeParameter": 0
+                }
+              ]
+            }
+          },
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "tx_context",
+                "name": "TxContext",
+                "typeArguments": []
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "display_registry",
+              "name": "Display",
+              "typeArguments": [
+                {
+                  "TypeParameter": 0
+                }
+              ]
+            }
+          },
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "display_registry",
+              "name": "DisplayCap",
+              "typeArguments": [
+                {
+                  "TypeParameter": 0
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "migration_cap_receiver": {
+        "visibility": "Friend",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [],
+        "return": [
+          "Address"
+        ]
+      },
+      "new": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": []
+          }
+        ],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "display_registry",
+                "name": "DisplayRegistry",
+                "typeArguments": []
+              }
+            }
+          },
+          {
+            "Struct": {
+              "address": "0x1",
+              "module": "internal",
+              "name": "Permit",
+              "typeArguments": [
+                {
+                  "TypeParameter": 0
+                }
+              ]
+            }
+          },
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "tx_context",
+                "name": "TxContext",
+                "typeArguments": []
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "display_registry",
+              "name": "Display",
+              "typeArguments": [
+                {
+                  "TypeParameter": 0
+                }
+              ]
+            }
+          },
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "display_registry",
+              "name": "DisplayCap",
+              "typeArguments": [
+                {
+                  "TypeParameter": 0
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "new_with_publisher": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": []
+          }
+        ],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "display_registry",
+                "name": "DisplayRegistry",
+                "typeArguments": []
+              }
+            }
+          },
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "package",
+                "name": "Publisher",
+                "typeArguments": []
+              }
+            }
+          },
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "tx_context",
+                "name": "TxContext",
+                "typeArguments": []
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "display_registry",
+              "name": "Display",
+              "typeArguments": [
+                {
+                  "TypeParameter": 0
+                }
+              ]
+            }
+          },
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "display_registry",
+              "name": "DisplayCap",
+              "typeArguments": [
+                {
+                  "TypeParameter": 0
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "set": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": []
+          }
+        ],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "display_registry",
+                "name": "Display",
+                "typeArguments": [
+                  {
+                    "TypeParameter": 0
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "display_registry",
+                "name": "DisplayCap",
+                "typeArguments": [
+                  {
+                    "TypeParameter": 0
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "Struct": {
+              "address": "0x1",
+              "module": "string",
+              "name": "String",
+              "typeArguments": []
+            }
+          },
+          {
+            "Struct": {
+              "address": "0x1",
+              "module": "string",
+              "name": "String",
+              "typeArguments": []
+            }
+          }
+        ],
+        "return": []
+      },
+      "share": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": []
+          }
+        ],
+        "parameters": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "display_registry",
+              "name": "Display",
+              "typeArguments": [
+                {
+                  "TypeParameter": 0
+                }
+              ]
+            }
+          }
+        ],
+        "return": []
+      },
+      "system_migration": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": [
+              "Key"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "display_registry",
+                "name": "DisplayRegistry",
+                "typeArguments": []
+              }
+            }
+          },
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "display_registry",
+                "name": "SystemMigrationCap",
+                "typeArguments": []
+              }
+            }
+          },
+          {
+            "Vector": {
+              "Struct": {
+                "address": "0x1",
+                "module": "string",
+                "name": "String",
+                "typeArguments": []
+              }
+            }
+          },
+          {
+            "Vector": {
+              "Struct": {
+                "address": "0x1",
+                "module": "string",
+                "name": "String",
+                "typeArguments": []
+              }
+            }
+          },
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "tx_context",
+                "name": "TxContext",
+                "typeArguments": []
+              }
+            }
+          }
+        ],
+        "return": []
+      },
+      "transfer_migration_cap": {
+        "visibility": "Private",
+        "isEntry": true,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "display_registry",
+              "name": "SystemMigrationCap",
+              "typeArguments": []
+            }
+          },
+          "Address"
+        ],
+        "return": []
+      },
+      "unset": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": []
+          }
+        ],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "display_registry",
+                "name": "Display",
+                "typeArguments": [
+                  {
+                    "TypeParameter": 0
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "display_registry",
+                "name": "DisplayCap",
+                "typeArguments": [
+                  {
+                    "TypeParameter": 0
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "Struct": {
+              "address": "0x1",
+              "module": "string",
+              "name": "String",
+              "typeArguments": []
+            }
+          }
+        ],
+        "return": []
+      }
+    }
+  },
   "dynamic_field": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "dynamic_field",
     "friends": [
@@ -12338,6 +13292,37 @@
               "TypeParameter": 1
             }
           }
+        ]
+      },
+      "exists": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": [
+              "Copy",
+              "Drop",
+              "Store"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "object",
+                "name": "UID",
+                "typeArguments": []
+              }
+            }
+          },
+          {
+            "TypeParameter": 0
+          }
+        ],
+        "return": [
+          "Bool"
         ]
       },
       "exists_": {
@@ -12645,11 +13630,113 @@
             }
           }
         ]
+      },
+      "remove_opt": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": [
+              "Copy",
+              "Drop",
+              "Store"
+            ]
+          },
+          {
+            "abilities": [
+              "Store"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "object",
+                "name": "UID",
+                "typeArguments": []
+              }
+            }
+          },
+          {
+            "TypeParameter": 0
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x1",
+              "module": "option",
+              "name": "Option",
+              "typeArguments": [
+                {
+                  "TypeParameter": 1
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "replace": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": [
+              "Copy",
+              "Drop",
+              "Store"
+            ]
+          },
+          {
+            "abilities": [
+              "Store"
+            ]
+          },
+          {
+            "abilities": [
+              "Store"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "object",
+                "name": "UID",
+                "typeArguments": []
+              }
+            }
+          },
+          {
+            "TypeParameter": 0
+          },
+          {
+            "TypeParameter": 1
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x1",
+              "module": "option",
+              "name": "Option",
+              "typeArguments": [
+                {
+                  "TypeParameter": 2
+                }
+              ]
+            }
+          }
+        ]
       }
     }
   },
   "dynamic_object_field": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "dynamic_object_field",
     "friends": [
@@ -12804,6 +13891,37 @@
               "TypeParameter": 1
             }
           }
+        ]
+      },
+      "exists": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": [
+              "Copy",
+              "Drop",
+              "Store"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "object",
+                "name": "UID",
+                "typeArguments": []
+              }
+            }
+          },
+          {
+            "TypeParameter": 0
+          }
+        ],
+        "return": [
+          "Bool"
         ]
       },
       "exists_": {
@@ -13150,11 +14268,116 @@
             "TypeParameter": 1
           }
         ]
+      },
+      "remove_opt": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": [
+              "Copy",
+              "Drop",
+              "Store"
+            ]
+          },
+          {
+            "abilities": [
+              "Store",
+              "Key"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "object",
+                "name": "UID",
+                "typeArguments": []
+              }
+            }
+          },
+          {
+            "TypeParameter": 0
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x1",
+              "module": "option",
+              "name": "Option",
+              "typeArguments": [
+                {
+                  "TypeParameter": 1
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "replace": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [
+          {
+            "abilities": [
+              "Copy",
+              "Drop",
+              "Store"
+            ]
+          },
+          {
+            "abilities": [
+              "Store",
+              "Key"
+            ]
+          },
+          {
+            "abilities": [
+              "Store",
+              "Key"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "object",
+                "name": "UID",
+                "typeArguments": []
+              }
+            }
+          },
+          {
+            "TypeParameter": 0
+          },
+          {
+            "TypeParameter": 1
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x1",
+              "module": "option",
+              "name": "Option",
+              "typeArguments": [
+                {
+                  "TypeParameter": 2
+                }
+              ]
+            }
+          }
+        ]
       }
     }
   },
   "ecdsa_k1": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "ecdsa_k1",
     "friends": [],
@@ -13229,7 +14452,7 @@
     }
   },
   "ecdsa_r1": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "ecdsa_r1",
     "friends": [],
@@ -13287,7 +14510,7 @@
     }
   },
   "ecvrf": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "ecvrf",
     "friends": [],
@@ -13326,7 +14549,7 @@
     }
   },
   "ed25519": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "ed25519",
     "friends": [],
@@ -13360,7 +14583,7 @@
     }
   },
   "event": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "event",
     "friends": [],
@@ -13405,7 +14628,7 @@
     }
   },
   "funds_accumulator": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "funds_accumulator",
     "friends": [
@@ -13716,7 +14939,7 @@
     }
   },
   "groth16": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "groth16",
     "friends": [],
@@ -14019,13 +15242,17 @@
     }
   },
   "group_ops": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "group_ops",
     "friends": [
       {
         "address": "0x2",
         "name": "bls12381"
+      },
+      {
+        "address": "0x2",
+        "name": "ristretto255"
       }
     ],
     "structs": {
@@ -14638,7 +15865,7 @@
     }
   },
   "hash": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "hash",
     "friends": [],
@@ -14681,7 +15908,7 @@
     }
   },
   "hex": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "hex",
     "friends": [],
@@ -14720,7 +15947,7 @@
     }
   },
   "hmac": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "hmac",
     "friends": [],
@@ -14751,7 +15978,7 @@
     }
   },
   "kiosk": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "kiosk",
     "friends": [
@@ -16711,7 +17938,7 @@
     }
   },
   "kiosk_extension": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "kiosk_extension",
     "friends": [],
@@ -17203,7 +18430,7 @@
     }
   },
   "linked_table": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "linked_table",
     "friends": [],
@@ -18131,7 +19358,7 @@
     }
   },
   "math": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "math",
     "friends": [],
@@ -18222,7 +19449,7 @@
     }
   },
   "nitro_attestation": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "nitro_attestation",
     "friends": [],
@@ -18610,7 +19837,7 @@
     }
   },
   "object": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "object",
     "friends": [
@@ -18641,6 +19868,10 @@
       {
         "address": "0x2",
         "name": "derived_object"
+      },
+      {
+        "address": "0x2",
+        "name": "display_registry"
       },
       {
         "address": "0x2",
@@ -19064,6 +20295,31 @@
           }
         ]
       },
+      "sui_display_registry_address": {
+        "visibility": "Friend",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [],
+        "return": [
+          "Address"
+        ]
+      },
+      "sui_display_registry_object_id": {
+        "visibility": "Friend",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "object",
+              "name": "UID",
+              "typeArguments": []
+            }
+          }
+        ]
+      },
       "uid_as_inner": {
         "visibility": "Public",
         "isEntry": false,
@@ -19165,7 +20421,7 @@
     }
   },
   "object_bag": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "object_bag",
     "friends": [],
@@ -19558,7 +20814,7 @@
     }
   },
   "object_table": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "object_table",
     "friends": [],
@@ -20072,7 +21328,7 @@
     }
   },
   "package": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "package",
     "friends": [],
@@ -20750,7 +22006,7 @@
     }
   },
   "party": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "party",
     "friends": [
@@ -20885,7 +22141,7 @@
     }
   },
   "pay": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "pay",
     "friends": [],
@@ -21184,7 +22440,7 @@
     }
   },
   "poseidon": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "poseidon",
     "friends": [],
@@ -21208,7 +22464,7 @@
     }
   },
   "priority_queue": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "priority_queue",
     "friends": [],
@@ -21491,7 +22747,7 @@
     }
   },
   "protocol_config": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "protocol_config",
     "friends": [
@@ -21518,7 +22774,7 @@
     }
   },
   "prover": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "prover",
     "friends": [],
@@ -21526,7 +22782,7 @@
     "exposedFunctions": {}
   },
   "random": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "random",
     "friends": [],
@@ -21960,8 +23216,929 @@
       }
     }
   },
+  "rangeproofs": {
+    "fileFormatVersion": 7,
+    "address": "0x2",
+    "name": "rangeproofs",
+    "friends": [],
+    "structs": {},
+    "exposedFunctions": {
+      "verify_bulletproofs_ristretto255": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Reference": {
+              "Vector": "U8"
+            }
+          },
+          "U8",
+          {
+            "Reference": {
+              "Vector": {
+                "Struct": {
+                  "address": "0x2",
+                  "module": "group_ops",
+                  "name": "Element",
+                  "typeArguments": [
+                    {
+                      "Struct": {
+                        "address": "0x2",
+                        "module": "ristretto255",
+                        "name": "G",
+                        "typeArguments": []
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "U8"
+        ],
+        "return": [
+          "Bool"
+        ]
+      }
+    }
+  },
+  "ristretto255": {
+    "fileFormatVersion": 7,
+    "address": "0x2",
+    "name": "ristretto255",
+    "friends": [],
+    "structs": {
+      "G": {
+        "abilities": {
+          "abilities": [
+            "Store"
+          ]
+        },
+        "typeParameters": [],
+        "fields": [
+          {
+            "name": "dummy_field",
+            "type": "Bool"
+          }
+        ]
+      },
+      "Scalar": {
+        "abilities": {
+          "abilities": [
+            "Store"
+          ]
+        },
+        "typeParameters": [],
+        "fields": [
+          {
+            "name": "dummy_field",
+            "type": "Bool"
+          }
+        ]
+      }
+    },
+    "exposedFunctions": {
+      "g_add": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "G",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "G",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "G",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "g_div": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "Scalar",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "G",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "G",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "g_from_bytes": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Reference": {
+              "Vector": "U8"
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "G",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "g_generator": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "G",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "g_identity": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "G",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "g_mul": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "Scalar",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "G",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "G",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "g_neg": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "G",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "G",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "g_sub": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "G",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "G",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "G",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "scalar_add": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "Scalar",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "Scalar",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "Scalar",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "scalar_div": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "Scalar",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "Scalar",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "Scalar",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "scalar_from_bytes": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Reference": {
+              "Vector": "U8"
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "Scalar",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "scalar_from_u64": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          "U64"
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "Scalar",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "scalar_inv": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "Scalar",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "Scalar",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "scalar_mul": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "Scalar",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "Scalar",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "Scalar",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "scalar_neg": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "Scalar",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "Scalar",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "scalar_one": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "Scalar",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "scalar_sub": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "Scalar",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x2",
+                "module": "group_ops",
+                "name": "Element",
+                "typeArguments": [
+                  {
+                    "Struct": {
+                      "address": "0x2",
+                      "module": "ristretto255",
+                      "name": "Scalar",
+                      "typeArguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "Scalar",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "scalar_zero": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [],
+        "return": [
+          {
+            "Struct": {
+              "address": "0x2",
+              "module": "group_ops",
+              "name": "Element",
+              "typeArguments": [
+                {
+                  "Struct": {
+                    "address": "0x2",
+                    "module": "ristretto255",
+                    "name": "Scalar",
+                    "typeArguments": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
   "sui": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "sui",
     "friends": [],
@@ -22011,7 +24188,7 @@
     }
   },
   "table": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "table",
     "friends": [],
@@ -22492,7 +24669,7 @@
     }
   },
   "table_vec": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "table_vec",
     "friends": [],
@@ -22923,7 +25100,7 @@
     }
   },
   "token": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "token",
     "friends": [],
@@ -25219,7 +27396,7 @@
     }
   },
   "transfer": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "transfer",
     "friends": [],
@@ -25615,7 +27792,7 @@
     }
   },
   "transfer_policy": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "transfer_policy",
     "friends": [],
@@ -26711,7 +28888,7 @@
     }
   },
   "tx_context": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "tx_context",
     "friends": [],
@@ -26926,7 +29103,7 @@
     }
   },
   "types": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "types",
     "friends": [],
@@ -26956,7 +29133,7 @@
     }
   },
   "url": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "url",
     "friends": [],
@@ -27087,7 +29264,7 @@
     }
   },
   "vdf": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "vdf",
     "friends": [],
@@ -27139,7 +29316,7 @@
     }
   },
   "vec_map": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "vec_map",
     "friends": [],
@@ -28070,7 +30247,7 @@
     }
   },
   "vec_set": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "vec_set",
     "friends": [],
@@ -28466,7 +30643,7 @@
     }
   },
   "versioned": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "versioned",
     "friends": [],
@@ -28740,7 +30917,7 @@
     }
   },
   "zklogin_verified_id": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "zklogin_verified_id",
     "friends": [],
@@ -29074,7 +31251,7 @@
     }
   },
   "zklogin_verified_issuer": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x2",
     "name": "zklogin_verified_issuer",
     "friends": [],

--- a/packages/sui/src/abis/0x3.json
+++ b/packages/sui/src/abis/0x3.json
@@ -1,6 +1,6 @@
 {
   "genesis": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x3",
     "name": "genesis",
     "friends": [],
@@ -217,7 +217,7 @@
     "exposedFunctions": {}
   },
   "stake_subsidy": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x3",
     "name": "stake_subsidy",
     "friends": [
@@ -416,7 +416,7 @@
     }
   },
   "staking_pool": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x3",
     "name": "staking_pool",
     "friends": [
@@ -1718,7 +1718,7 @@
     }
   },
   "storage_fund": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x3",
     "name": "storage_fund",
     "friends": [
@@ -1946,7 +1946,7 @@
     }
   },
   "sui_system": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x3",
     "name": "sui_system",
     "friends": [
@@ -2041,6 +2041,27 @@
           {
             "Vector": "Address"
           }
+        ]
+      },
+      "active_validator_stake_amount": {
+        "visibility": "Public",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x3",
+                "module": "sui_system",
+                "name": "SuiSystemState",
+                "typeArguments": []
+              }
+            }
+          },
+          "Address"
+        ],
+        "return": [
+          "U64"
         ]
       },
       "active_validator_voting_powers": {
@@ -3530,7 +3551,7 @@
     }
   },
   "sui_system_state_inner": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x3",
     "name": "sui_system_state_inner",
     "friends": [
@@ -4527,13 +4548,11 @@
             }
           },
           {
-            "Reference": {
-              "Struct": {
-                "address": "0x2",
-                "module": "object",
-                "name": "ID",
-                "typeArguments": []
-              }
+            "Struct": {
+              "address": "0x2",
+              "module": "object",
+              "name": "ID",
+              "typeArguments": []
             }
           }
         ],
@@ -5994,7 +6013,7 @@
     }
   },
   "validator": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x3",
     "name": "validator",
     "friends": [
@@ -8643,7 +8662,7 @@
     }
   },
   "validator_cap": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x3",
     "name": "validator_cap",
     "friends": [
@@ -8797,15 +8816,13 @@
           }
         ],
         "return": [
-          {
-            "Reference": "Address"
-          }
+          "Address"
         ]
       }
     }
   },
   "validator_set": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x3",
     "name": "validator_set",
     "friends": [
@@ -9177,6 +9194,36 @@
       }
     },
     "exposedFunctions": {
+      "active_validator": {
+        "visibility": "Friend",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x3",
+                "module": "validator_set",
+                "name": "ValidatorSet",
+                "typeArguments": []
+              }
+            }
+          },
+          "Address"
+        ],
+        "return": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x3",
+                "module": "validator",
+                "name": "Validator",
+                "typeArguments": []
+              }
+            }
+          }
+        ]
+      },
       "active_validator_addresses": {
         "visibility": "Friend",
         "isEntry": false,
@@ -9196,6 +9243,36 @@
         "return": [
           {
             "Vector": "Address"
+          }
+        ]
+      },
+      "active_validator_mut": {
+        "visibility": "Friend",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x3",
+                "module": "validator_set",
+                "name": "ValidatorSet",
+                "typeArguments": []
+              }
+            }
+          },
+          "Address"
+        ],
+        "return": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x3",
+                "module": "validator",
+                "name": "Validator",
+                "typeArguments": []
+              }
+            }
           }
         ]
       },
@@ -9320,6 +9397,66 @@
         ],
         "return": []
       },
+      "any_validator": {
+        "visibility": "Friend",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x3",
+                "module": "validator_set",
+                "name": "ValidatorSet",
+                "typeArguments": []
+              }
+            }
+          },
+          "Address"
+        ],
+        "return": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x3",
+                "module": "validator",
+                "name": "Validator",
+                "typeArguments": []
+              }
+            }
+          }
+        ]
+      },
+      "any_validator_mut": {
+        "visibility": "Friend",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x3",
+                "module": "validator_set",
+                "name": "ValidatorSet",
+                "typeArguments": []
+              }
+            }
+          },
+          "Address"
+        ],
+        "return": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x3",
+                "module": "validator",
+                "name": "Validator",
+                "typeArguments": []
+              }
+            }
+          }
+        ]
+      },
       "assert_no_pending_or_active_duplicates": {
         "visibility": "Friend",
         "isEntry": false,
@@ -9368,6 +9505,66 @@
         ],
         "return": [
           "U64"
+        ]
+      },
+      "candidate_validator": {
+        "visibility": "Friend",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x3",
+                "module": "validator_set",
+                "name": "ValidatorSet",
+                "typeArguments": []
+              }
+            }
+          },
+          "Address"
+        ],
+        "return": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x3",
+                "module": "validator",
+                "name": "Validator",
+                "typeArguments": []
+              }
+            }
+          }
+        ]
+      },
+      "candidate_validator_mut": {
+        "visibility": "Friend",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x3",
+                "module": "validator_set",
+                "name": "ValidatorSet",
+                "typeArguments": []
+              }
+            }
+          },
+          "Address"
+        ],
+        "return": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x3",
+                "module": "validator",
+                "name": "Validator",
+                "typeArguments": []
+              }
+            }
+          }
         ]
       },
       "convert_to_fungible_staked_sui": {
@@ -9516,156 +9713,6 @@
         "return": [
           {
             "Reference": {
-              "Struct": {
-                "address": "0x3",
-                "module": "validator",
-                "name": "Validator",
-                "typeArguments": []
-              }
-            }
-          }
-        ]
-      },
-      "get_validator_mut": {
-        "visibility": "Friend",
-        "isEntry": false,
-        "typeParameters": [],
-        "parameters": [
-          {
-            "MutableReference": {
-              "Vector": {
-                "Struct": {
-                  "address": "0x3",
-                  "module": "validator",
-                  "name": "Validator",
-                  "typeArguments": []
-                }
-              }
-            }
-          },
-          "Address"
-        ],
-        "return": [
-          {
-            "MutableReference": {
-              "Struct": {
-                "address": "0x3",
-                "module": "validator",
-                "name": "Validator",
-                "typeArguments": []
-              }
-            }
-          }
-        ]
-      },
-      "get_validator_mut_with_ctx": {
-        "visibility": "Friend",
-        "isEntry": false,
-        "typeParameters": [],
-        "parameters": [
-          {
-            "MutableReference": {
-              "Struct": {
-                "address": "0x3",
-                "module": "validator_set",
-                "name": "ValidatorSet",
-                "typeArguments": []
-              }
-            }
-          },
-          {
-            "Reference": {
-              "Struct": {
-                "address": "0x2",
-                "module": "tx_context",
-                "name": "TxContext",
-                "typeArguments": []
-              }
-            }
-          }
-        ],
-        "return": [
-          {
-            "MutableReference": {
-              "Struct": {
-                "address": "0x3",
-                "module": "validator",
-                "name": "Validator",
-                "typeArguments": []
-              }
-            }
-          }
-        ]
-      },
-      "get_validator_mut_with_ctx_including_candidates": {
-        "visibility": "Friend",
-        "isEntry": false,
-        "typeParameters": [],
-        "parameters": [
-          {
-            "MutableReference": {
-              "Struct": {
-                "address": "0x3",
-                "module": "validator_set",
-                "name": "ValidatorSet",
-                "typeArguments": []
-              }
-            }
-          },
-          {
-            "Reference": {
-              "Struct": {
-                "address": "0x2",
-                "module": "tx_context",
-                "name": "TxContext",
-                "typeArguments": []
-              }
-            }
-          }
-        ],
-        "return": [
-          {
-            "MutableReference": {
-              "Struct": {
-                "address": "0x3",
-                "module": "validator",
-                "name": "Validator",
-                "typeArguments": []
-              }
-            }
-          }
-        ]
-      },
-      "get_validator_mut_with_verified_cap": {
-        "visibility": "Friend",
-        "isEntry": false,
-        "typeParameters": [],
-        "parameters": [
-          {
-            "MutableReference": {
-              "Struct": {
-                "address": "0x3",
-                "module": "validator_set",
-                "name": "ValidatorSet",
-                "typeArguments": []
-              }
-            }
-          },
-          {
-            "Reference": {
-              "Struct": {
-                "address": "0x3",
-                "module": "validator_cap",
-                "name": "ValidatorOperationCap",
-                "typeArguments": []
-              }
-            }
-          },
-          "Bool"
-        ],
-        "return": [
-          {
-            "MutableReference": {
               "Struct": {
                 "address": "0x3",
                 "module": "validator",
@@ -9877,6 +9924,66 @@
           "U64"
         ]
       },
+      "pending_validator": {
+        "visibility": "Friend",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x3",
+                "module": "validator_set",
+                "name": "ValidatorSet",
+                "typeArguments": []
+              }
+            }
+          },
+          "Address"
+        ],
+        "return": [
+          {
+            "Reference": {
+              "Struct": {
+                "address": "0x3",
+                "module": "validator",
+                "name": "Validator",
+                "typeArguments": []
+              }
+            }
+          }
+        ]
+      },
+      "pending_validator_mut": {
+        "visibility": "Friend",
+        "isEntry": false,
+        "typeParameters": [],
+        "parameters": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x3",
+                "module": "validator_set",
+                "name": "ValidatorSet",
+                "typeArguments": []
+              }
+            }
+          },
+          "Address"
+        ],
+        "return": [
+          {
+            "MutableReference": {
+              "Struct": {
+                "address": "0x3",
+                "module": "validator",
+                "name": "Validator",
+                "typeArguments": []
+              }
+            }
+          }
+        ]
+      },
       "pool_exchange_rates": {
         "visibility": "Friend",
         "isEntry": false,
@@ -9893,13 +10000,11 @@
             }
           },
           {
-            "Reference": {
-              "Struct": {
-                "address": "0x2",
-                "module": "object",
-                "name": "ID",
-                "typeArguments": []
-              }
+            "Struct": {
+              "address": "0x2",
+              "module": "object",
+              "name": "ID",
+              "typeArguments": []
             }
           }
         ],
@@ -10155,35 +10260,6 @@
         ],
         "return": []
       },
-      "request_set_commission_rate": {
-        "visibility": "Friend",
-        "isEntry": false,
-        "typeParameters": [],
-        "parameters": [
-          {
-            "MutableReference": {
-              "Struct": {
-                "address": "0x3",
-                "module": "validator_set",
-                "name": "ValidatorSet",
-                "typeArguments": []
-              }
-            }
-          },
-          "U64",
-          {
-            "Reference": {
-              "Struct": {
-                "address": "0x2",
-                "module": "tx_context",
-                "name": "TxContext",
-                "typeArguments": []
-              }
-            }
-          }
-        ],
-        "return": []
-      },
       "request_withdraw_stake": {
         "visibility": "Friend",
         "isEntry": false,
@@ -10370,13 +10446,11 @@
             }
           },
           {
-            "Reference": {
-              "Struct": {
-                "address": "0x2",
-                "module": "object",
-                "name": "ID",
-                "typeArguments": []
-              }
+            "Struct": {
+              "address": "0x2",
+              "module": "object",
+              "name": "ID",
+              "typeArguments": []
             }
           }
         ],
@@ -10525,7 +10599,7 @@
     }
   },
   "validator_wrapper": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x3",
     "name": "validator_wrapper",
     "friends": [
@@ -10650,7 +10724,7 @@
     }
   },
   "voting_power": {
-    "fileFormatVersion": 6,
+    "fileFormatVersion": 7,
     "address": "0x3",
     "name": "voting_power",
     "friends": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,8 +168,8 @@ importers:
   packages/sui:
     dependencies:
       '@mysten/sui':
-        specifier: ~2.4.0
-        version: 2.4.0(typescript@5.9.2)
+        specifier: ~2.17.0
+        version: 2.17.0(typescript@5.9.2)
       '@typemove/move':
         specifier: workspace:*
         version: link:../move
@@ -558,22 +558,22 @@ packages:
   '@mysten/bcs@1.8.0':
     resolution: {integrity: sha512-bDoLN1nN+XPONsvpNyNyqYHndM3PKWS419GLeRnbLoWyNm4bnyD1X4luEpJLLDq400hBuXiCan4RWjofvyTUIQ==}
 
-  '@mysten/bcs@2.0.2':
-    resolution: {integrity: sha512-c/nVRPJEV1fRZdKXhysVsy/yCPdiFt7jn6A4/7W2LH1ZPSVPzRkxtLY362D0zaLuBnyT5Y9d9nFLm3ixI8Goug==}
+  '@mysten/bcs@2.0.5':
+    resolution: {integrity: sha512-Dop9Xq36DPLlsmIDQZvUg4uJeBBxIGirgp2OXGaEff+mtLKFBoW2HnE3aSTSSpiMQH9XRhjwtiM16zFJhFqz0Q==}
 
   '@mysten/sui@1.38.0':
     resolution: {integrity: sha512-tH6V4BJsYi5d97MOiLoOhyldrYxkm/cu8dYV52asqh1i88HrSVMbPAJ9sVoeWN2Ju+QsJ/Go4ldSjdCkaBCyJQ==}
     engines: {node: '>=18'}
 
-  '@mysten/sui@2.4.0':
-    resolution: {integrity: sha512-2EG5+lTypWMgU3lWyKlcjopQ++Ae9BkoROOBVcJ6mYwM5o1IcKnoc7rFqr94KQClYmBFV2aFz5+aKm5okatoBw==}
+  '@mysten/sui@2.17.0':
+    resolution: {integrity: sha512-TrS1BCPm4V6rC69MBejmcqnKIyJ5t1iksax4XA9jWarZxAAp9LMmdxEBebejyDT/yAJxYIf3fNm5WBkHE2qnIw==}
     engines: {node: '>=22'}
 
   '@mysten/utils@0.2.0':
     resolution: {integrity: sha512-CM6kJcJHX365cK6aXfFRLBiuyXc5WSBHQ43t94jqlCAIRw8umgNcTb5EnEA9n31wPAQgLDGgbG/rCUISCTJ66w==}
 
-  '@mysten/utils@0.3.1':
-    resolution: {integrity: sha512-36KhxG284uhDdSnlkyNaS6fzKTX9FpP2WQWOwUKIRsqQFFIm2ooCf2TP1IuqrtMpkairwpiWkAS0eg7cpemVzg==}
+  '@mysten/utils@0.3.3':
+    resolution: {integrity: sha512-gVHn5toh24eXXLEyBknwwM2F/tbDgqPX0yj77KtHjuoYUallcQ9vSwGfGsAy39IcTB259Yprt/ZOEwdup+zrpA==}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -3783,9 +3783,9 @@ snapshots:
       '@mysten/utils': 0.2.0
       '@scure/base': 1.2.6
 
-  '@mysten/bcs@2.0.2':
+  '@mysten/bcs@2.0.5':
     dependencies:
-      '@mysten/utils': 0.3.1
+      '@mysten/utils': 0.3.3
       '@scure/base': 2.0.0
 
   '@mysten/sui@1.38.0(typescript@5.9.2)':
@@ -3807,13 +3807,13 @@ snapshots:
       - '@gql.tada/vue-support'
       - typescript
 
-  '@mysten/sui@2.4.0(typescript@5.9.2)':
+  '@mysten/sui@2.17.0(typescript@5.9.2)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.12.0)
-      '@mysten/bcs': 2.0.2
-      '@mysten/utils': 0.3.1
-      '@noble/curves': 2.0.1
-      '@noble/hashes': 2.0.1
+      '@mysten/bcs': 2.0.5
+      '@mysten/utils': 0.3.3
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 2.2.0
       '@protobuf-ts/grpcweb-transport': 2.11.1
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
@@ -3833,7 +3833,7 @@ snapshots:
     dependencies:
       '@scure/base': 1.2.6
 
-  '@mysten/utils@0.3.1':
+  '@mysten/utils@0.3.3':
     dependencies:
       '@scure/base': 2.0.0
 


### PR DESCRIPTION
## Summary

Bumps `@mysten/sui` from `~2.4.0` to `~2.17.0` (13 minor versions of upstream changes). Regenerated `packages/sui/src/builtin/{0x1,0x2,0x3}.ts` and their backing ABIs from current testnet state.

No source-code changes needed in `@typemove/sui` or `@typemove/move` — this SDK update is binary/ABI clean for our use. The new builtins compile against the upgraded SDK, all tests still pass, and the sibling chain packages (`@typemove/aptos`, `@typemove/iota`) are unaffected (they use their own SDKs).

## Verified

- `pnpm --filter @typemove/sui build` — clean
- `pnpm --filter @typemove/sui test` — 15/15 pass
- `pnpm --filter @typemove/iota exec tsc` — clean
- `pnpm --filter @typemove/aptos exec tsc` — clean
- `pnpm --filter @typemove/move test` — 6/6 pass

## Test plan

- [x] @typemove/sui builds against SDK 2.17.0
- [x] @typemove/sui tests pass on the new builtins
- [x] @typemove/iota and @typemove/aptos still build (no shared-code regressions)
- [ ] Reviewer: confirm the ABI churn in `packages/sui/src/abis/0x2.json` (~5K lines diff) is just upstream module additions, not anything semantically suspicious.

🤖 Generated with [Claude Code](https://claude.com/claude-code)