### PR TITLE
chore(repo): ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ types
 
 # macOS Finder metadata
 .DS_Store
-**/.DS_Store
 
 # Logs
 logs

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ types
 .idea
 .run
 
+# macOS Finder metadata
+.DS_Store
+**/.DS_Store
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
## Summary

Add `.DS_Store` (and `**/.DS_Store` for nested dirs) to `.gitignore`. macOS Finder drops these files into any directory it views, and they regularly appear as untracked when running `git status` — e.g. `packages/sui/src/.DS_Store` showed up during my recent SDK work.

One-line repo hygiene fix, no functional impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)