### PR TITLE
release(major): upgrade major sui/aptos version, fixes

### DIFF
--- a/packages/aptos/src/account-resource-client.test.ts
+++ b/packages/aptos/src/account-resource-client.test.ts
@@ -16,7 +16,7 @@ describe('account resource client', () => {
     const allPoolResources = await accountResourceClient.matchAll(ACCOUNT_ADDRESS, poolType)
     expect(allPoolResources.length).to.greaterThan(1)
     for (const r of allPoolResources) {
-      expect(r.data_decoded.x_reserve).not.be.undefined
+      expect(r.data_decoded.x_reserve).to.not.equal(undefined)
     }
 
     const poolTypeWithAptos = amm.Pool.type(aptos_coin.AptosCoin.type(), ANY_TYPE)
@@ -28,13 +28,13 @@ describe('account resource client', () => {
 
   test('test single resource', async () => {
     const x = await accountResourceClient.matchExact(ACCOUNT_ADDRESS, vault.Vault.type())
-    expect(x).not.be.undefined
+    expect(x).to.not.equal(undefined)
   })
 
   test('test single resource with type', async () => {
     const type = amm.Pool.type(aptos_coin.AptosCoin.type(), aptos_coin.AptosCoin.type())
     const x = await accountResourceClient.matchExact(ACCOUNT_ADDRESS, type)
-    expect(x).not.be.undefined
+    expect(x).to.not.equal(undefined)
   })
 
   test('test single resource with wrong pattern', async () => {


### PR DESCRIPTION
## Summary

Converts the three getter-style chai assertions in `packages/aptos/src/account-resource-client.test.ts` from `expect(x).not.be.undefined` to call-style `expect(x).to.not.equal(undefined)`.

These were the repo's **only** lint warnings (`@typescript-eslint/no-unused-expressions`). Beyond silencing the rule, the getter form is genuinely fragile — a typo'd assertion (`expect(x).not.be.undefind`) silently no-ops, whereas the call form actually executes. `pnpm lint` is now warning-free (0 errors, 0 warnings).

## Test plan

- [x] `pnpm lint` — clean, no warnings
- [x] `pnpm --filter @typemove/aptos test` — 20 pass, 1 skip, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)