### PR TITLE
fix(publish): correct files globs so dist/src actually ship

### DIFF
--- a/packages/aptos/package.json
+++ b/packages/aptos/package.json
@@ -15,10 +15,10 @@
     "typemove-aptos": "./dist/esm/codegen/run.js"
   },
   "files": [
-    "**/package.json",
-    "{dist,src}",
-    "!**/*.test.{js,ts}",
-    "!{dist,src}/*/tests"
+    "dist",
+    "src",
+    "!**/*.test.*",
+    "!**/tests"
   ],
   "scripts": {
     "_gen": "pnpm gen:test && tsx src/codegen/run.ts -t src/builtin -a src/abis",

--- a/packages/iota/package.json
+++ b/packages/iota/package.json
@@ -15,10 +15,10 @@
     "typemove-iota": "./dist/esm/codegen/run.js"
   },
   "files": [
-    "**/package.json",
-    "{dist,src}",
-    "!**/*.test.{js,ts}",
-    "!{dist,src}/*/tests"
+    "dist",
+    "src",
+    "!**/*.test.*",
+    "!**/tests"
   ],
   "scripts": {
     "_gen": "pnpm gen:test && tsx src/codegen/run.ts -t src/builtin -a src/abis",

--- a/packages/move/package.json
+++ b/packages/move/package.json
@@ -8,10 +8,10 @@
     "./codegen": "./dist/esm/codegen/index.js"
   },
   "files": [
-    "**/package.json",
-    "{dist,src}",
-    "!**/*.test.{js,ts}",
-    "!{dist,src}/*/tests"
+    "dist",
+    "src",
+    "!**/*.test.*",
+    "!**/tests"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/sui/package.json
+++ b/packages/sui/package.json
@@ -15,10 +15,10 @@
     "typemove-sui": "./dist/esm/codegen/run.js"
   },
   "files": [
-    "**/package.json",
-    "{dist,src}",
-    "!**/*.test.{js,ts}",
-    "!{dist,src}/*/tests"
+    "dist",
+    "src",
+    "!**/*.test.*",
+    "!**/tests"
   ],
   "scripts": {
     "_gen": "pnpm gen:test && tsx src/codegen/run.ts -t src/builtin -a src/abis",


### PR DESCRIPTION
## Summary

**`@typemove 2.0.0` is a broken npm publish** — `@typemove/move` shipped with only `LICENSE` + `package.json` (no `dist/`), so any consumer hits `Cannot find module '@typemove/move/dist/esm/index.js'`. This blocks the sentio-sdk upgrade to the gRPC line entirely.

### Root cause — pnpm 10 expanded the brace, pnpm 11 doesn't

The `files` field used **brace expansion**:

```json
"files": ["**/package.json", "{dist,src}", "!**/*.test.{js,ts}", "!{dist,src}/*/tests"]
```

This had shipped fine for every 1.x release (1.13.4 = 87 files) because **pnpm 10's** `pnpm pack` expanded `{dist,src}`. The deps-update PR (#171) bumped the publish toolchain to **pnpm 11** (`packageManager` + `pnpm/action-setup@v6`), and **pnpm 11 dropped brace expansion in `files`** — so `{dist,src}` matched nothing and only `**/package.json` shipped. 2.0.0 was simply the first release packed under pnpm 11, which is why a years-old `files` field broke now.

Verified under pnpm 11.3.0: `pnpm pack` with the brace pattern = 2 files; with explicit `dist`/`src` entries = full tarball. (`npm pack` never expanded the brace either, so the pattern was always non-portable.) The `.gitignore` `dist` rule was a red herring — a correct `files` whitelist publishes gitignored build output fine.

### Fix

Brace-free globs on all four published packages:

```json
"files": ["dist", "src", "!**/*.test.*", "!**/tests"]
```

`!**/*.test.*` also closes a second gap — the old `*.test.{js,ts}` never excluded emitted `.test.d.ts` / `.test.js.map`, so test artifacts were leaking into the tarball.

### Verified

`npm pack --dry-run` per package after a clean rebuild:

| Package | Files | dist/esm/index.js | codegen bin | src/abis |
|---|---|---|---|---|
| move | 46 | ✅ | ✅ (codegen/index.js) | n/a |
| aptos | 75 | ✅ | ✅ run.js | ✅ |
| sui | 85 | ✅ | ✅ run.js | ✅ |
| iota | 70 | ✅ | ✅ run.js | ✅ |

Zero `.test.*` / `tests/` / stale `dist/cjs` leakage in any package.

## Follow-up

2.0.0 is broken on npm — this needs a **2.0.1 republish** once merged. The sentio-sdk gRPC upgrade is blocked until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
