### PR TITLE
fix(publish): add repository field for npm provenance

### DIFF
--- a/packages/aptos/package.json
+++ b/packages/aptos/package.json
@@ -2,6 +2,11 @@
   "name": "@typemove/aptos",
   "version": "1.0.0-development",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sentioxyz/typemove.git",
+    "directory": "packages/aptos"
+  },
   "type": "module",
   "exports": {
     ".": "./dist/esm/index.js",
@@ -37,6 +42,5 @@
     "commander": "^14.0.0",
     "prettier": "^3.2.4",
     "radash": "^12.0.0"
-  },
-  "url": "https://github.com/sentioxyz/typemove"
+  }
 }

--- a/packages/iota/package.json
+++ b/packages/iota/package.json
@@ -2,6 +2,11 @@
   "name": "@typemove/iota",
   "version": "1.0.0-development",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sentioxyz/typemove.git",
+    "directory": "packages/iota"
+  },
   "type": "module",
   "exports": {
     ".": "./dist/esm/index.js",
@@ -37,6 +42,5 @@
     "commander": "^14.0.0",
     "prettier": "^3.2.4",
     "radash": "^12.0.0"
-  },
-  "url": "https://github.com/sentioxyz/typemove"
+  }
 }

--- a/packages/move/package.json
+++ b/packages/move/package.json
@@ -2,6 +2,11 @@
   "name": "@typemove/move",
   "version": "1.0.0-development",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sentioxyz/typemove.git",
+    "directory": "packages/move"
+  },
   "type": "module",
   "exports": {
     ".": "./dist/esm/index.js",
@@ -19,6 +24,5 @@
   },
   "dependencies": {
     "radash": "^12.0.0"
-  },
-  "url": "https://github.com/sentioxyz/typemove"
+  }
 }

--- a/packages/sui/package.json
+++ b/packages/sui/package.json
@@ -2,6 +2,11 @@
   "name": "@typemove/sui",
   "version": "1.0.0-development",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sentioxyz/typemove.git",
+    "directory": "packages/sui"
+  },
   "type": "module",
   "exports": {
     ".": "./dist/esm/index.js",
@@ -36,6 +41,5 @@
     "commander": "^14.0.0",
     "prettier": "^3.2.4",
     "radash": "^12.0.0"
-  },
-  "url": "https://github.com/sentioxyz/typemove"
+  }
 }


### PR DESCRIPTION
## Summary
OIDC trusted publishing (enabled in #174) generates a sigstore provenance bundle that npm validates against `package.json` `repository.url`. The packages had a stray top-level `"url"` field (ignored by npm) instead of a `"repository"` object, causing publish to fail:

```
[E422] 422 Unprocessable Entity - PUT https://registry.npmjs.org/@typemove%2fmove
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match "https://github.com/sentioxyz/typemove"
```

This adds a proper `repository` object (with `directory`) to all four packages.

## Notes
- OIDC itself worked in the #174 run (id-token fetched, 200) — this was the only remaining blocker.

## Test plan
- [ ] Merge and confirm the publish workflow gets past the provenance check

🤖 Generated with [Claude Code](https://claude.com/claude-code)