### PR TITLE
chore(claude): enable typescript-lsp plugin for this repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "enabledPlugins": {
-    "claude-md-management@claude-plugins-official": true
+    "claude-md-management@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true
   },
   "hooks": {
     "PreToolUse": [


### PR DESCRIPTION
Add typescript-lsp@claude-plugins-official to the project-level enabledPlugins so Claude Code sessions in this repo get TypeScript LSP features (goToDefinition, findReferences, hover, etc.) without each contributor having to enable it at the user level.