### PR TITLE
chore(deps): drop unused tslib (no-op at target esnext)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "prettier-package-json": "^2.8.0",
     "prettier-plugin-sh": "^0.18.0",
     "semantic-release": "^24.0.0",
-    "tslib": "^2.6.2",
     "tsx": "^4.20.0",
     "typedoc": "^0.28.0",
     "typescript": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       semantic-release:
         specifier: ^24.0.0
         version: 24.0.0(typescript@6.0.3)
-      tslib:
-        specifier: ^2.6.2
-        version: 2.8.1
       tsx:
         specifier: ^4.20.0
         version: 4.20.5

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "importHelpers": true,
     "declaration": true,
     "declarationMap": true,
     "alwaysStrict": true,


### PR DESCRIPTION
## Summary
- Remove `tslib` from root `devDependencies`.
- Remove `importHelpers: true` from the root `tsconfig.json` (it was a no-op at our target).

## Why
`importHelpers: true` instructs TypeScript to import runtime helpers (e.g. `__awaiter`, `__rest`, `__spreadArray`) from `tslib` rather than inlining them. But the root tsconfig targets `esnext` — TypeScript only emits those helpers when it has to down-level newer syntax. At `esnext`, nothing is down-leveled, so no helpers are ever emitted.

Verified across the four published packages:

| Check | Result |
|---|---|
| `tslib` declared as a runtime dep | None of `@typemove/{move,aptos,sui,iota}` |
| `from 'tslib'` / `require('tslib')` in `packages/` or `examples/` | 0 hits |
| `tslib` references in built `packages/*/dist` | 0 across move/aptos/sui/iota |

So `tslib` is pure dead weight in our `devDependencies`, and `importHelpers: true` has no effect.

## Test plan
- [x] `pnpm install` clean
- [x] `pnpm build:all` clean (all 4 packages rebuild)
- [x] `pnpm test:all` clean (all suites pass)
- [x] Post-build `grep -rln tslib packages/*/dist` → 0 hits
- [ ] CI green

## Reversibility
If we ever lower `target` (e.g. to `es2015` or earlier) and want to keep emitted output small, re-enable `importHelpers: true` and add `tslib` back as a runtime dep in each published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)