### PR TITLE
chore(repo): consolidate pnpm config into pnpm-workspace.yaml

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-engine-strict = true
-enable-pre-post-scripts=true
-# shamefully-hoist = true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 packages:
   - 'packages/*'
   - 'examples/*'
+
+engineStrict: true
+
 # pnpm 11 errors on ignored build scripts unless explicitly approved here.
 # esbuild (used by tsx) and unrs-resolver (eslint-import-resolver-typescript's
 # native binary) both ship legitimate postinstall builds.


### PR DESCRIPTION
## Summary
- Move `engine-strict` → `engineStrict` in `pnpm-workspace.yaml` (pnpm 11 supports workspace-level config)
- Drop `.npmrc` — the remaining entries were no-ops:
  - `enable-pre-post-scripts` only governs custom `pre<x>`/`post<x>` script pairs (none in this repo); `preinstall`/`postinstall` are standard lifecycle hooks that always run
  - `shamefully-hoist` was already commented out

Verified `pnpm config get engine-strict` still returns `true` after the move.

## Test plan
- [x] `pnpm config get engine-strict` → `true`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)