### PR TITLE
chore(lint): source ignores from .gitignore, drop unused @eslint/compat

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,14 @@
 import unusedImports from 'eslint-plugin-unused-imports'
 import { configs } from 'typescript-eslint'
-import { defineConfig } from "eslint/config";
+import { defineConfig, includeIgnoreFile } from "eslint/config";
 import { importX } from 'eslint-plugin-import-x'
 import eslintConfigPrettier from "eslint-config-prettier/flat";
+import { fileURLToPath } from 'node:url'
+
+const gitignorePath = fileURLToPath(new URL('.gitignore', import.meta.url))
 
 export default defineConfig([
+  includeIgnoreFile(gitignorePath, { gitignoreResolution: true }),
   // ...configs.recommendedTypeChecked,
   ...configs.recommended,
   importX.flatConfigs.recommended,
@@ -13,16 +17,7 @@ export default defineConfig([
   {
     ignores: [
       '**/,.*',
-      '**/*.config.ts',
-      '**/*.config.js',
-      '**/*.config.cjs',
-      '**/*.config.mjs',
-      '**/dist',
-      '**/debug',
-      '**/lib',
-      '**/docs',
-      '**/gen',
-      '**/types',
+      '**/*.config.{ts,js,cjs,mjs}',
       '**/builtin',
     ]
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "test:all": "pnpm --filter \"./packages/*\" test"
   },
   "devDependencies": {
-    "@eslint/compat": "^2.1.0",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
     "@ls-lint/ls-lint": "^2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     devDependencies:
-      '@eslint/compat':
-        specifier: ^2.1.0
-        version: 2.1.0(eslint@10.4.0)
       '@eslint/eslintrc':
         specifier: ^3.3.5
         version: 3.3.5
@@ -418,15 +415,6 @@ packages:
   '@eslint-community/regexpp@4.12.2':
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-
-  '@eslint/compat@2.1.0':
-    resolution: {integrity: sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-    peerDependencies:
-      eslint: ^8.40 || 9 || 10
-    peerDependenciesMeta:
-      eslint:
-        optional: true
 
   '@eslint/config-array@0.23.5':
     resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
@@ -3070,12 +3058,6 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
-
-  '@eslint/compat@2.1.0(eslint@10.4.0)':
-    dependencies:
-      '@eslint/core': 1.2.1
-    optionalDependencies:
-      eslint: 10.4.0
 
   '@eslint/config-array@0.23.5':
     dependencies:


### PR DESCRIPTION
## What

Feed `.gitignore` into the ESLint flat config and remove the now-redundant manual ignores.

- Import `includeIgnoreFile` from `eslint/config` (exported there since the eslint 10 bump on `main`) and add it as the first config entry with `{ gitignoreResolution: true }`.
- Drop the manual ignores that `.gitignore` now covers: `**/dist`, `**/debug`, `**/docs`, `**/types`.
- Drop `**/lib` and `**/gen` — neither directory exists in the repo.
- Remove the unused `@eslint/compat` devDependency. It was never imported; `includeIgnoreFile` now comes from `eslint/config` directly (no replacement dep needed).

Remaining manual ignores are intentional — they are **not** covered by `.gitignore`: the config-file globs (`**/*.config.{ts,js,cjs,mjs}`), `**/builtin`, and the `**/,.*` dotfile pattern.

## Why

The manual `ignores` list duplicated patterns already in `.gitignore`, so they drifted out of sync. Sourcing them from `.gitignore` keeps a single source of truth, and `@eslint/compat` was dead weight.

## Verification

- `pnpm lint` → exit 0.
- Confirmed a `src/builtin/*.ts` file is still reported as ignored.
- Verified `eslint/config` exports `includeIgnoreFile` at runtime on eslint 10.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)