### PR TITLE
fix(types): make TypeDescriptor's type argument inferable

### DIFF
--- a/packages/move/src/types.ts
+++ b/packages/move/src/types.ts
@@ -18,6 +18,20 @@ export class TypeDescriptor<T = any> {
   mutable: boolean
   typeArgs: TypeDescriptor[]
 
+  /**
+   * Phantom marker that ties the type argument `T` into TypeDescriptor's
+   * structural shape. `T` is otherwise unused, which means `TypeDescriptor<A>`
+   * and `TypeDescriptor<B>` are identical types and callers cannot infer `T`
+   * from a `TypeDescriptor<T>` parameter — e.g. `MovePoolAdaptor.poolType` in
+   * @sentio/sdk, where the lost inference surfaces as `unknown` pool callbacks.
+   * It matters most when two copies of this package coexist in one dependency
+   * tree (a descriptor produced by one copy is consumed against another): the
+   * two declarations are compared structurally, and without a `T`-using member
+   * structural inference yields no candidate. Declared (not initialized) so it
+   * stays purely type-level — no runtime field is emitted.
+   */
+  declare readonly __inferredType?: T
+
   constructor(symbol: string, typeParams?: TypeDescriptor[]) {
     this.qname = symbol
     this.reference = false


### PR DESCRIPTION
## Problem

`TypeDescriptor<T>` never used `T` in any member — it was a **phantom** type parameter. Consequences:

- `TypeDescriptor<A>` and `TypeDescriptor<B>` are identical types, so callers **cannot infer `T`** from a `TypeDescriptor<T>` parameter.
- This breaks inference at sites like `MovePoolAdaptor.poolType`, `Sui/IotaObjectProcessor.objectType`, and aptos `resourceType` in `@sentio/sdk`: pool/object callback params collapse to `unknown` → **`TS18046: 'pool' is of type 'unknown'`**.
- It's **worst across duplicate package copies**. When two `@typemove/move` versions coexist in one tree (e.g. a processor pins 2.0.4 while `@sentio/sdk` bundles 2.0.5), a descriptor produced by one copy is compared *structurally* against the other's `TypeDescriptor<T>`. With a phantom `T`, structural inference yields **no candidate at all** → `T = unknown`, even when the descriptor is concretely `TypeDescriptor<Pool<…>>`.

Real-world repro: AptosDex pool callbacks in `sentio-processors` required explicit `new AptosDex<pool.Pool<any,any,any>>(...)` annotations purely to work around this.

## Fix

Add an optional, `readonly`, `declare`-only phantom member so `T` participates in `TypeDescriptor`'s structural shape:

```ts
declare readonly __inferredType?: T
```

- **Type-only**: `declare` emits no runtime field (verified: present in `.d.ts`, absent from `.js`). Instances are unchanged, so serialization/`Object.keys` behavior is identical.
- Makes `TypeDescriptor` **covariant in `T`** (the natural direction for a descriptor).

## Validation

- ✅ `@typemove/move|aptos|sui|iota` all build clean against the new type (generated code + coders are the heaviest `TypeDescriptor` consumers).
- ✅ typemove unit tests pass.
- ✅ Assignment-safety check against the real built type — 6 common patterns (`<any>` interop both ways, normally-constructed descriptors, covariant widening, generic coder pass-through, `TypeDescriptor[]` arrays) all compile.
- ✅ Cross-copy inference now resolves `T` (two structurally-identical-but-distinct declarations).
- ✅ Every hand-written `TypeDescriptor` usage in `@sentio/sdk` is an inference site (`TypeDescriptor<T>` / `infer T`) — they only benefit; no concrete-type assignment that covariance would reject.

## Notes

- Forward-looking robustness: it fully fixes the skew case only once **both** coexisting copies are on a version that includes this change. Pinning a single `@typemove/move` (e.g. via `resolutions`) remains the immediate fix for an already-published phantom copy.
- Theoretical risk: code that assigned `TypeDescriptor<Wider>` into a `TypeDescriptor<Narrower>` slot (and not via `any`) would now be correctly rejected. No such usage found in typemove or `@sentio/sdk`; a downstream CI build is the recommended final gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)