### PR TITLE
fix(sui): decode 0x1::type_name::TypeName flattened to a string

### DIFF
--- a/packages/sui/src/move-coder.test.ts
+++ b/packages/sui/src/move-coder.test.ts
@@ -99,6 +99,15 @@ describe('Test move coder', () => {
     const res2 = await coder.decodeType(nonBcsData, type)
     expect(res2).to.deep.eq(res)
   })
+
+  test('decode type_name flattened to string', async () => {
+    const coder = defaultMoveCoder()
+    // gRPC's unified Object.json flattens 0x1::type_name::TypeName to its inner
+    // string; the decoder should re-wrap it so `.name` accessors keep working.
+    const name = '5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN'
+    const res = await coder.decodeType(name, parseMoveType('0x1::type_name::TypeName'))
+    expect(res).to.deep.eq({ name })
+  })
 })
 
 const bcsData =

--- a/packages/sui/src/move-coder.ts
+++ b/packages/sui/src/move-coder.ts
@@ -61,6 +61,18 @@ export class MoveCoder extends AbstractMoveCoder<ModuleWithAddress, SuiEventInpu
       }
       return super.decode(data, type)
     }
+    // gRPC's unified Object.json also flattens 0x1::type_name::TypeName to its
+    // inner string (e.g. "<addr>::coin::COIN") — re-wrap to `{ name: '...' }` so
+    // downstream `.name` accessors keep working. Without this the string falls
+    // into the generic struct walk and decodes to `{ name: undefined }`. The
+    // BCS-shaped path (`{ name: { bytes: ... } }`) is delegated to super.decode,
+    // whose field walk hits the ascii::String case.
+    if (type.qname === '0x1::type_name::TypeName') {
+      if (typeof data === 'string') {
+        return { name: data } as any
+      }
+      return super.decode(data, type)
+    }
     switch (type.qname) {
       case '0x1::ascii::Char':
         if (data !== undefined && typeof data !== 'string') {


### PR DESCRIPTION
## Problem

gRPC's unified `Object.json` flattens `0x1::type_name::TypeName` to its inner string (e.g. `"<addr>::coin::COIN"`), the same way it flattens `UID`, `ID`, `ascii::String`, etc.

`MoveCoder.decode()` special-cases all of those flattened forms but has no case for `TypeName`, so the string falls into the generic struct field walk: it looks up `data['name']` on a plain string and decodes to `{ name: undefined }` (serializes as `{}`). Any downstream accessor like `position.coin_type_a.name` silently gets `undefined` — e.g. code building a coin type as `'0x' + x.coin_type_a.name` ends up with the literal string `"0xundefined"`.

## Fix

Handle `0x1::type_name::TypeName` before the switch, mirroring the existing `0x2::object::UID` handling:

- string input (gRPC flattened JSON) → re-wrap to `{ name: '...' }`, matching the generated `TypeName` shape
- non-string input (BCS-shaped `{ name: { bytes: ... } }`) → delegate to `super.decode`, whose field walk hits the existing `ascii::String` case

## Testing

Added a unit test; `pnpm --filter @typemove/sui test` passes (18/18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)